### PR TITLE
Add introspective integration planning tool

### DIFF
--- a/synergyx/tools/field_observation.py
+++ b/synergyx/tools/field_observation.py
@@ -1,0 +1,500 @@
+"""Field observation analysis inspired by nocturnal control missions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from .base import AnalysisTool
+
+
+VisibilityLevel = {
+    "clear": 0.05,
+    "light_fog": 0.15,
+    "haze": 0.25,
+    "low_light": 0.35,
+    "shadowed": 0.45,
+    "dense_fog": 0.55,
+    "storm": 0.65,
+    "blackout": 0.8,
+}
+
+SPECIES_THREAT = {
+    "raven": 0.45,
+    "wolf": 0.6,
+    "spider": 0.35,
+    "bat": 0.25,
+    "moth": 0.2,
+    "owl": 0.3,
+}
+
+
+def _safe_mean(values: Iterable[float]) -> Optional[float]:
+    values = list(values)
+    return mean(values) if values else None
+
+
+def _bounded(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def _visibility_penalty(level: str) -> float:
+    level = (level or "").lower().replace(" ", "_")
+    if level in VisibilityLevel:
+        return VisibilityLevel[level]
+    if "moon" in level:
+        return 0.35
+    if "shadow" in level:
+        return 0.45
+    if "rain" in level or "storm" in level:
+        return 0.6
+    return 0.1 if level else 0.2
+
+
+def _species_pressure(entries: Mapping[str, float]) -> float:
+    total = 0.0
+    weight = 0.0
+    for species, count in entries.items():
+        base = SPECIES_THREAT.get(species, 0.3)
+        if any(keyword in species for keyword in ("venom", "predator", "wolf")):
+            base = max(base, 0.6)
+        total += base * count
+        weight += count
+    return _bounded(total / weight if weight else 0.0)
+
+
+def _normalize_signal(signal: Optional[float]) -> Optional[float]:
+    if signal is None:
+        return None
+    return _bounded(signal / 100.0)
+
+
+def _link_weight(edge: Mapping[str, Any]) -> float:
+    weight = edge.get("weight")
+    try:
+        return float(weight)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@dataclass
+class WindowSnapshot:
+    """Normalized metrics for a single observation window."""
+
+    window_id: str
+    crew: str
+    throughput_per_hour: Optional[float]
+    incidents: int
+    signal_strength: Optional[float]
+    visibility: str
+    species_totals: Mapping[str, float]
+    ambient_noise: Optional[float]
+    notes: Optional[str]
+
+
+class NocturnalFieldInsightTool(AnalysisTool):
+    """Fuse crew cadence, network loads, and wildlife pressure at night."""
+
+    @property
+    def name(self) -> str:
+        return "nocturnal_field_insight"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Evaluate night operations observations to derive risk, limiting factors, "
+            "and recommended control adjustments."
+        )
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "observation_windows": {
+                    "type": "array",
+                    "description": "Time-sliced field notes from the shift.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "window_id": {"type": "string"},
+                            "crew": {"type": "string"},
+                            "tasks_completed": {"type": "number"},
+                            "duration_minutes": {"type": "number", "minimum": 0},
+                            "incidents": {"type": "integer", "minimum": 0},
+                            "signal_strength": {"type": "number"},
+                            "visibility": {"type": "string"},
+                            "wildlife": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "species": {"type": "string"},
+                                        "count": {"type": "number", "minimum": 0},
+                                    },
+                                    "required": ["species"],
+                                },
+                                "default": [],
+                            },
+                            "ambient": {
+                                "type": "object",
+                                "properties": {
+                                    "noise_db": {"type": "number"},
+                                    "temperature_c": {"type": "number"},
+                                },
+                            },
+                            "notes": {"type": "string"},
+                        },
+                    },
+                    "default": [],
+                },
+                "relay_links": {
+                    "type": "array",
+                    "description": "Communication or supply relays with weightings.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "source": {"type": "string"},
+                            "target": {"type": "string"},
+                            "weight": {"type": "number"},
+                        },
+                        "required": ["source", "target", "weight"],
+                    },
+                    "default": [],
+                },
+                "environment_markers": {
+                    "type": "array",
+                    "description": "Environment cues such as red-moon, ground-mist, etc.",
+                    "items": {"type": "string"},
+                    "default": [],
+                },
+                "support_assets": {
+                    "type": "object",
+                    "description": "Portable power, thermal, or rescue asset status.",
+                    "properties": {
+                        "battery_hours": {"type": "number"},
+                        "spare_power_ratio": {"type": "number"},
+                        "thermal_margin": {"type": "number"},
+                    },
+                },
+            },
+        }
+
+    async def execute(
+        self,
+        *,
+        observation_windows: Optional[Sequence[Mapping[str, Any]]] = None,
+        relay_links: Optional[Sequence[Mapping[str, Any]]] = None,
+        environment_markers: Optional[Sequence[str]] = None,
+        support_assets: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        windows = [self._parse_window(item) for item in observation_windows or []]
+        crews = self._aggregate_crews(windows)
+        wildlife_pressure = _species_pressure(self._merge_species(windows))
+        network_diagnostics = self._network_health(relay_links or [])
+        environment_summary = self._environment_profile(environment_markers or [], support_assets or {})
+
+        risk_score, limiting_factors = self._compose_risk(
+            crews=crews,
+            wildlife_pressure=wildlife_pressure,
+            network=network_diagnostics,
+            environment=environment_summary,
+        )
+
+        return {
+            "field_state": {
+                "crews": crews,
+                "network": network_diagnostics,
+                "environment": environment_summary,
+                "wildlife_pressure": wildlife_pressure,
+                "window_count": len(windows),
+            },
+            "control_focus": {
+                "risk_score": risk_score,
+                "limiting_factors": limiting_factors,
+                "recommendations": self._recommendations(
+                    risk=risk_score,
+                    crews=crews,
+                    environment=environment_summary,
+                    network=network_diagnostics,
+                    wildlife_pressure=wildlife_pressure,
+                ),
+            },
+            "notes": self._collect_notes(windows),
+        }
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+
+    def _parse_window(self, payload: Mapping[str, Any]) -> WindowSnapshot:
+        duration_minutes = max(float(payload.get("duration_minutes") or 0.0), 0.0)
+        tasks = float(payload.get("tasks_completed") or 0.0)
+        throughput = None
+        if duration_minutes > 0:
+            throughput = (tasks / duration_minutes) * 60.0
+
+        wildlife_entries = {}
+        for entry in payload.get("wildlife", []) or []:
+            species = str(entry.get("species", "unknown")).strip().lower()
+            if not species:
+                continue
+            count = entry.get("count", 1)
+            try:
+                wildlife_entries[species] = wildlife_entries.get(species, 0.0) + max(float(count), 0.0)
+            except (TypeError, ValueError):
+                wildlife_entries[species] = wildlife_entries.get(species, 0.0) + 1.0
+
+        ambient = payload.get("ambient") or {}
+        ambient_noise = ambient.get("noise_db")
+        try:
+            ambient_noise = float(ambient_noise) if ambient_noise is not None else None
+        except (TypeError, ValueError):
+            ambient_noise = None
+
+        signal = payload.get("signal_strength")
+        try:
+            signal = float(signal) if signal is not None else None
+        except (TypeError, ValueError):
+            signal = None
+
+        return WindowSnapshot(
+            window_id=str(payload.get("window_id", "")) or "window",
+            crew=str(payload.get("crew", "unknown")).strip() or "unknown",
+            throughput_per_hour=throughput,
+            incidents=max(int(payload.get("incidents") or 0), 0),
+            signal_strength=_normalize_signal(signal),
+            visibility=str(payload.get("visibility", "unknown")).strip().lower(),
+            species_totals=wildlife_entries,
+            ambient_noise=ambient_noise,
+            notes=str(payload.get("notes")) if payload.get("notes") else None,
+        )
+
+    def _merge_species(self, windows: Sequence[WindowSnapshot]) -> Dict[str, float]:
+        totals: Dict[str, float] = {}
+        for window in windows:
+            for species, count in window.species_totals.items():
+                totals[species] = totals.get(species, 0.0) + count
+        return totals
+
+    def _aggregate_crews(self, windows: Sequence[WindowSnapshot]) -> Dict[str, Dict[str, Any]]:
+        grouped: MutableMapping[str, Dict[str, Any]] = {}
+        for window in windows:
+            crew = window.crew
+            stats = grouped.setdefault(
+                crew,
+                {
+                    "windows": 0,
+                    "throughput_per_hour": [],
+                    "incidents": 0,
+                    "signal_strength": [],
+                    "visibility_penalties": [],
+                    "ambient_noise": [],
+                },
+            )
+            stats["windows"] += 1
+            if window.throughput_per_hour is not None:
+                stats["throughput_per_hour"].append(window.throughput_per_hour)
+            stats["incidents"] += window.incidents
+            if window.signal_strength is not None:
+                stats["signal_strength"].append(window.signal_strength)
+            stats["visibility_penalties"].append(_visibility_penalty(window.visibility))
+            if window.ambient_noise is not None:
+                stats["ambient_noise"].append(window.ambient_noise)
+
+        summary: Dict[str, Dict[str, Any]] = {}
+        for crew, stats in grouped.items():
+            total_incidents = stats["incidents"]
+            window_count = max(stats["windows"], 1)
+            incident_rate = total_incidents / window_count
+            summary[crew] = {
+                "windows": stats["windows"],
+                "incident_rate": round(incident_rate, 2),
+                "total_incidents": total_incidents,
+                "avg_throughput_per_hour": _safe_mean(stats["throughput_per_hour"]),
+                "avg_signal_strength": _safe_mean(stats["signal_strength"]),
+                "avg_visibility_penalty": _safe_mean(stats["visibility_penalties"]),
+                "avg_ambient_noise": _safe_mean(stats["ambient_noise"]),
+            }
+        return summary
+
+    # ------------------------------------------------------------------
+    # Analysis helpers
+    # ------------------------------------------------------------------
+
+    def _network_health(self, links: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+        if not links:
+            return {
+                "nodes": 0,
+                "links": 0,
+                "avg_weight": None,
+                "bottleneck": None,
+                "stability": 0.5,
+            }
+
+        node_weights: MutableMapping[str, List[float]] = {}
+        link_weights: List[float] = []
+        for edge in links:
+            source = str(edge.get("source", "")).strip() or "unknown"
+            target = str(edge.get("target", "")).strip() or "unknown"
+            weight = _link_weight(edge)
+            node_weights.setdefault(source, []).append(weight)
+            node_weights.setdefault(target, []).append(weight)
+            link_weights.append(weight)
+
+        avg_weight = _safe_mean(link_weights)
+        weakest = min(link_weights) if link_weights else None
+        stability = _bounded((avg_weight or 0.0) / (abs(weakest) + 1.0)) if weakest is not None else 0.6
+
+        if weakest is not None and weakest < 0:
+            stability *= 0.5
+
+        return {
+            "nodes": len(node_weights),
+            "links": len(link_weights),
+            "avg_weight": avg_weight,
+            "bottleneck": weakest,
+            "stability": round(_bounded(stability), 3),
+        }
+
+    def _environment_profile(
+        self,
+        markers: Sequence[str],
+        assets: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        lowered = [marker.strip().lower() for marker in markers if isinstance(marker, str)]
+        penalties = []
+        if any("red moon" in marker for marker in lowered):
+            penalties.append(0.3)
+        if any(marker for marker in lowered if "rain" in marker or "wet" in marker):
+            penalties.append(0.25)
+        if any("drone" in marker for marker in lowered):
+            penalties.append(0.2)
+        if any("predator" in marker for marker in lowered):
+            penalties.append(0.35)
+
+        support = {
+            "battery_hours": self._safe_float(assets.get("battery_hours")),
+            "spare_power_ratio": self._safe_float(assets.get("spare_power_ratio")),
+            "thermal_margin": self._safe_float(assets.get("thermal_margin")),
+        }
+
+        resilience = 0.5
+        available_metrics = [value for value in support.values() if value is not None]
+        if available_metrics:
+            resilience = _bounded(mean(available_metrics) / 10.0)
+
+        return {
+            "markers": lowered,
+            "support": support,
+            "environment_penalty": round(_bounded(mean(penalties) if penalties else 0.0), 3),
+            "support_resilience": round(resilience, 3),
+        }
+
+    def _compose_risk(
+        self,
+        *,
+        crews: Mapping[str, Mapping[str, Any]],
+        wildlife_pressure: float,
+        network: Mapping[str, Any],
+        environment: Mapping[str, Any],
+    ) -> Tuple[float, List[str]]:
+        factors: List[Tuple[str, float]] = []
+
+        avg_visibility = _safe_mean(
+            value.get("avg_visibility_penalty")
+            for value in crews.values()
+            if value.get("avg_visibility_penalty") is not None
+        )
+        if avg_visibility is not None:
+            factors.append(("visibility", avg_visibility))
+
+        incident_pressure = _safe_mean(value.get("incident_rate") for value in crews.values())
+        if incident_pressure is not None:
+            factors.append(("incident_rate", min(incident_pressure / 5.0, 0.6)))
+
+        if network:
+            stability = network.get("stability")
+            if stability is not None:
+                factors.append(("network", 0.6 - (stability * 0.4)))
+
+        if wildlife_pressure:
+            factors.append(("wildlife", wildlife_pressure * 0.6))
+
+        env_penalty = environment.get("environment_penalty")
+        if env_penalty:
+            factors.append(("environment", env_penalty))
+
+        support_resilience = environment.get("support_resilience")
+        if support_resilience is not None:
+            factors.append(("support_gap", max(0.2 - support_resilience * 0.2, 0.0)))
+
+        if not factors:
+            return 0.2, []
+
+        total = _bounded(mean(score for _, score in factors))
+        limiting = [name for name, score in factors if score >= total * 0.9 and score > 0.1]
+        return round(total, 3), limiting
+
+    def _recommendations(
+        self,
+        *,
+        risk: float,
+        crews: Mapping[str, Mapping[str, Any]],
+        environment: Mapping[str, Any],
+        network: Mapping[str, Any],
+        wildlife_pressure: float,
+    ) -> List[str]:
+        actions: List[str] = []
+
+        high_incident_crews = [
+            crew
+            for crew, stats in crews.items()
+            if stats.get("incident_rate", 0) >= 1.0
+        ]
+        if high_incident_crews:
+            actions.append(
+                "Rotate crews with elevated incident rates (" + ", ".join(high_incident_crews) + ") to reduce fatigue."
+            )
+
+        if network.get("stability") is not None and network["stability"] < 0.4:
+            actions.append(
+                "Re-route through alternate relays; current weakest link weight %.2f is degrading comms." % network.get("bottleneck", 0.0)
+            )
+
+        if wildlife_pressure >= 0.4:
+            actions.append(
+                "Deploy acoustic deterrents or adjust patrol paths to avoid concentrated wildlife pressure zones."
+            )
+
+        if environment.get("environment_penalty", 0) >= 0.3:
+            actions.append("Escalate weather countermeasures and tighten safety perimeter for low visibility.")
+
+        support = environment.get("support", {})
+        if support.get("battery_hours") is not None and support["battery_hours"] < 4:
+            actions.append("Stage recharge kits; battery reserves below 4h could compromise response depth.")
+
+        if not actions:
+            if risk <= 0.25:
+                actions.append("Maintain current cadence; conditions stable with moderate buffers.")
+            else:
+                actions.append("Increase monitoring cadence; assess crew telemetry every 30 minutes for drift.")
+
+        return actions
+
+    def _collect_notes(self, windows: Sequence[WindowSnapshot]) -> List[str]:
+        notes = []
+        for window in windows:
+            if window.notes:
+                notes.append(f"[{window.crew}] {window.notes}")
+        return notes
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/synergyx/tools/introspective_integration.py
+++ b/synergyx/tools/introspective_integration.py
@@ -1,0 +1,460 @@
+"""Introspective integration analysis inspired by reflective pathways."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from .base import AnalysisTool
+
+
+@dataclass
+class CapabilityProfile:
+    """Normalized attributes for an existing capability module."""
+
+    name: str
+    focus: str
+    reliability: float
+    load: float
+    dependencies: Sequence[str]
+
+
+@dataclass
+class IntegrationCandidate:
+    """Description of a potential integration expansion."""
+
+    integration_id: str
+    integrates_with: Sequence[str]
+    expected_gain: float
+    complexity: float
+    risk_notes: Sequence[str]
+
+
+FOCUS_WEIGHTS = {
+    "control": 1.0,
+    "stability": 0.9,
+    "exploration": 0.75,
+    "support": 0.85,
+    "coordination": 0.8,
+}
+
+
+class IntrospectiveIntegrationTool(AnalysisTool):
+    """Reflect on current capabilities and chart the next integration arc."""
+
+    @property
+    def name(self) -> str:
+        return "introspective_integration"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Balance existing capabilities, readiness signals, and integration candidates "
+            "to surface the next deliberate expansion path."
+        )
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "capabilities": {
+                    "type": "array",
+                    "description": "Known capabilities with reliability and load markers.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "focus": {"type": "string"},
+                            "reliability": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                            "load": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                            "dependencies": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": [],
+                            },
+                        },
+                        "required": ["name"],
+                    },
+                    "default": [],
+                },
+                "integration_candidates": {
+                    "type": "array",
+                    "description": "Potential integrations to evaluate.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "integration_id": {"type": "string"},
+                            "integrates_with": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": [],
+                            },
+                            "expected_gain": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                            "complexity": {"type": "number", "minimum": 0.0},
+                            "risk_notes": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": [],
+                            },
+                        },
+                        "required": ["integration_id"],
+                    },
+                    "default": [],
+                },
+                "introspection_signals": {
+                    "type": "object",
+                    "description": "Signals such as friction, momentum, or vision weightings.",
+                    "additionalProperties": {"type": "number"},
+                    "default": {},
+                },
+                "expansion_objectives": {
+                    "type": "array",
+                    "description": "Strategic objectives like lunar-scouting or canopy-mapping.",
+                    "items": {"type": "string"},
+                    "default": [],
+                },
+            },
+        }
+
+    async def execute(
+        self,
+        *,
+        capabilities: Optional[Sequence[Mapping[str, Any]]] = None,
+        integration_candidates: Optional[Sequence[Mapping[str, Any]]] = None,
+        introspection_signals: Optional[Mapping[str, float]] = None,
+        expansion_objectives: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        profiles = [self._parse_capability(item) for item in capabilities or []]
+        candidates = [self._parse_candidate(item) for item in integration_candidates or []]
+        signals = {str(k).lower(): float(v) for k, v in (introspection_signals or {}).items() if self._is_number(v)}
+        objectives = [str(obj).strip().lower() for obj in expansion_objectives or [] if str(obj).strip()]
+
+        capability_matrix = self._capability_matrix(profiles)
+        canvas = self._integration_canvas(profiles, objectives)
+        prioritised = self._score_candidates(candidates, profiles, signals, objectives)
+        reflective = self._reflective_feedback(capability_matrix, signals)
+
+        return {
+            "capability_matrix": capability_matrix,
+            "integration_canvas": canvas,
+            "prioritized_integrations": prioritised,
+            "introspective_feedback": reflective,
+        }
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+
+    def _parse_capability(self, payload: Mapping[str, Any]) -> CapabilityProfile:
+        name = str(payload.get("name", "")).strip() or "unnamed"
+        focus = str(payload.get("focus", "support")).strip().lower() or "support"
+        reliability = self._bounded_float(payload.get("reliability"), fallback=0.5)
+        load = self._bounded_float(payload.get("load"), fallback=0.4)
+        dependencies = [
+            str(dep).strip()
+            for dep in payload.get("dependencies", []) or []
+            if str(dep).strip()
+        ]
+        return CapabilityProfile(name=name, focus=focus, reliability=reliability, load=load, dependencies=dependencies)
+
+    def _parse_candidate(self, payload: Mapping[str, Any]) -> IntegrationCandidate:
+        integration_id = str(payload.get("integration_id", "")).strip() or "candidate"
+        integrates_with = [
+            str(name).strip()
+            for name in payload.get("integrates_with", []) or []
+            if str(name).strip()
+        ]
+        expected_gain = self._bounded_float(payload.get("expected_gain"), fallback=0.35)
+        complexity = max(self._safe_float(payload.get("complexity")) or 1.0, 0.1)
+        risk_notes = [
+            str(note).strip()
+            for note in payload.get("risk_notes", []) or []
+            if str(note).strip()
+        ]
+        return IntegrationCandidate(
+            integration_id=integration_id,
+            integrates_with=integrates_with,
+            expected_gain=expected_gain,
+            complexity=complexity,
+            risk_notes=risk_notes,
+        )
+
+    # ------------------------------------------------------------------
+    # Capability analysis
+    # ------------------------------------------------------------------
+
+    def _capability_matrix(self, profiles: Sequence[CapabilityProfile]) -> Dict[str, Any]:
+        if not profiles:
+            return {
+                "focus_distribution": {},
+                "average_reliability": None,
+                "load_pressure": None,
+                "dependency_clusters": [],
+            }
+
+        focus_counts: MutableMapping[str, int] = {}
+        reliability_values: List[float] = []
+        load_values: List[float] = []
+        dependency_map: MutableMapping[str, List[str]] = {}
+
+        for profile in profiles:
+            focus_counts[profile.focus] = focus_counts.get(profile.focus, 0) + 1
+            reliability_values.append(profile.reliability)
+            load_values.append(profile.load)
+            for dependency in profile.dependencies:
+                dependency_map.setdefault(dependency, []).append(profile.name)
+
+        dependency_clusters = [
+            {"dependency": dep, "supported_by": sorted(set(sources))}
+            for dep, sources in dependency_map.items()
+            if len(sources) > 1
+        ]
+
+        return {
+            "focus_distribution": focus_counts,
+            "average_reliability": round(mean(reliability_values), 3),
+            "load_pressure": round(mean(load_values), 3),
+            "dependency_clusters": dependency_clusters,
+        }
+
+    def _integration_canvas(
+        self,
+        profiles: Sequence[CapabilityProfile],
+        objectives: Sequence[str],
+    ) -> Dict[str, Any]:
+        """Generate a symbolic canvas linking anchors (stone, canopy, lunar, solar)."""
+
+        anchors = {
+            "bedrock": [profile.name for profile in profiles if profile.focus in {"control", "stability"}],
+            "canopy": [profile.name for profile in profiles if profile.focus in {"exploration", "support"}],
+            "luminous": [profile.name for profile in profiles if profile.reliability >= 0.7],
+            "frontier": [profile.name for profile in profiles if profile.load < 0.4],
+        }
+        motive_themes = []
+        if any("lunar" in obj or "night" in obj for obj in objectives):
+            motive_themes.append("lunar-reflection")
+        if any("solar" in obj or "radiant" in obj or "day" in obj for obj in objectives):
+            motive_themes.append("solar-burst")
+        if any("forest" in obj or "canopy" in obj for obj in objectives):
+            motive_themes.append("canopy-resonance")
+        if any("path" in obj or "trail" in obj for obj in objectives):
+            motive_themes.append("trail-continuum")
+        if not motive_themes:
+            motive_themes.append("equilibrium-axis")
+
+        return {
+            "anchors": anchors,
+            "motive_themes": motive_themes,
+            "objectives": objectives,
+        }
+
+    # ------------------------------------------------------------------
+    # Candidate scoring
+    # ------------------------------------------------------------------
+
+    def _score_candidates(
+        self,
+        candidates: Sequence[IntegrationCandidate],
+        profiles: Sequence[CapabilityProfile],
+        signals: Mapping[str, float],
+        objectives: Sequence[str],
+    ) -> List[Dict[str, Any]]:
+        if not candidates:
+            return []
+
+        profile_lookup = {profile.name: profile for profile in profiles}
+        control_bias = signals.get("control", 0.0)
+        discovery_bias = signals.get("discovery", signals.get("exploration", 0.0))
+        friction = signals.get("friction", 0.0)
+        momentum = signals.get("momentum", 0.0)
+        clarity = signals.get("clarity", 0.0)
+
+        themed_objectives = {
+            "lunar": any("lunar" in obj or "moon" in obj for obj in objectives),
+            "canopy": any("forest" in obj or "canopy" in obj for obj in objectives),
+            "solar": any("solar" in obj or "sun" in obj for obj in objectives),
+        }
+
+        scored: List[Tuple[float, Dict[str, Any]]] = []
+        for candidate in candidates:
+            anchors = [profile_lookup.get(name) for name in candidate.integrates_with]
+            anchors = [profile for profile in anchors if profile is not None]
+            anchor_weight = mean(
+                FOCUS_WEIGHTS.get(profile.focus, 0.7) * profile.reliability
+                for profile in anchors
+            ) if anchors else 0.5
+
+            load_penalty = mean(profile.load for profile in anchors) if anchors else 0.3
+            load_penalty = min(load_penalty * 0.6, 0.4)
+
+            complexity_penalty = min(candidate.complexity / 10.0, 0.7)
+            bias_bonus = (control_bias * 0.2) + (discovery_bias * 0.15) + (momentum * 0.1) + (clarity * 0.1)
+            friction_offset = max(0.0, 1.0 - friction * 0.5)
+
+            thematic_bonus = 0.0
+            if themed_objectives["lunar"] and any("night" in rn or "shadow" in rn for rn in candidate.risk_notes):
+                thematic_bonus += 0.05
+            if themed_objectives["canopy"] and any(
+                name for name in candidate.integrates_with if "canopy" in name.lower() or "forest" in name.lower()
+            ):
+                thematic_bonus += 0.05
+            if themed_objectives["solar"] and candidate.expected_gain >= 0.6:
+                thematic_bonus += 0.05
+
+            score = (
+                candidate.expected_gain
+                * (0.8 + anchor_weight)
+                * friction_offset
+            ) - (complexity_penalty + load_penalty) + bias_bonus + thematic_bonus
+            score = max(score, 0.0)
+
+            lane = self._lane_alignment(candidate, anchors, signals)
+            rationale = self._build_rationale(candidate, anchors, score, lane)
+            scored.append((score, {
+                "integration_id": candidate.integration_id,
+                "score": round(score, 3),
+                "lane_alignment": lane,
+                "rationale": rationale,
+                "phased_path": self._phased_path(candidate, anchors),
+            }))
+
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [entry for _, entry in scored]
+
+    def _lane_alignment(
+        self,
+        candidate: IntegrationCandidate,
+        anchors: Sequence[CapabilityProfile],
+        signals: Mapping[str, float],
+    ) -> Dict[str, float]:
+        stability_lane = mean(profile.reliability for profile in anchors) if anchors else 0.5
+        exploration_lane = signals.get("discovery", signals.get("exploration", 0.0)) + candidate.expected_gain
+        synthesis_lane = (signals.get("clarity", 0.0) * 0.5) + (signals.get("momentum", 0.0) * 0.5)
+
+        return {
+            "stability_lane": round(min(stability_lane, 1.0), 3),
+            "exploration_lane": round(min(exploration_lane, 1.5), 3),
+            "synthesis_lane": round(min(synthesis_lane + 0.3, 1.2), 3),
+        }
+
+    def _build_rationale(
+        self,
+        candidate: IntegrationCandidate,
+        anchors: Sequence[CapabilityProfile],
+        score: float,
+        lane: Mapping[str, float],
+    ) -> str:
+        phrases = []
+        if anchors:
+            primary = max(anchors, key=lambda prof: prof.reliability)
+            phrases.append(
+                f"Anchored by {primary.name} ({primary.focus}) with reliability {primary.reliability:.2f}."
+            )
+        else:
+            phrases.append("Integration would establish a new anchor node.")
+
+        if score >= 0.8:
+            phrases.append("Projected to expand control surface meaningfully.")
+        elif score >= 0.45:
+            phrases.append("Delivers balanced growth with manageable risk.")
+        else:
+            phrases.append("Treat as exploratory spike; monitor for signal drift.")
+
+        if lane["exploration_lane"] > 1.0:
+            phrases.append("Exploration lane is energized; schedule a discovery sprint.")
+        if lane["stability_lane"] < 0.6:
+            phrases.append("Stability lane light—stage safety harness tests.")
+
+        if candidate.risk_notes:
+            phrases.append("Risk notes: " + "; ".join(candidate.risk_notes))
+
+        return " ".join(phrases)
+
+    def _phased_path(
+        self,
+        candidate: IntegrationCandidate,
+        anchors: Sequence[CapabilityProfile],
+    ) -> List[str]:
+        phases = [
+            "Diagnostic echo — validate dependencies and telemetry hooks.",
+            "Pilot braid — weave integration alongside primary anchor for two cycles.",
+            "Load shift — gradually elevate responsibility while monitoring control signals.",
+        ]
+
+        if not anchors:
+            phases.insert(0, "Foundation rune — prototype baseline scaffolding before pairing.")
+        if candidate.complexity > 6:
+            phases.append("Red moon watch — keep fallback routine live during ramp.")
+        if candidate.expected_gain >= 0.7:
+            phases.append("Aurora unlock — broadcast learning across collaborating modules.")
+        return phases
+
+    # ------------------------------------------------------------------
+    # Feedback
+    # ------------------------------------------------------------------
+
+    def _reflective_feedback(
+        self,
+        matrix: Mapping[str, Any],
+        signals: Mapping[str, float],
+    ) -> Dict[str, Any]:
+        focus_distribution = matrix.get("focus_distribution", {})
+        if not focus_distribution:
+            return {
+                "summary": "No capabilities registered; establish a core stone before branching.",
+                "control_core": None,
+                "expansion_vector": None,
+                "recommended_checkpoint": "map-first-node",
+            }
+
+        dominant_focus = max(focus_distribution.items(), key=lambda item: item[1])[0]
+        control_core = "stable" if dominant_focus in {"control", "stability"} else "adaptive"
+        expansion_vector = "trail" if signals.get("momentum", 0) > 0.5 else "stillness"
+
+        summary_parts = [
+            f"Control core is {control_core} with dominant focus on {dominant_focus}.",
+            f"Reliability mean at {matrix.get('average_reliability')} and load pressure at {matrix.get('load_pressure')}.",
+        ]
+
+        if signals.get("friction", 0) > 0.4:
+            summary_parts.append("Friction elevated — introduce deliberate pauses for recalibration.")
+        if signals.get("clarity", 0) >= 0.6:
+            summary_parts.append("Clarity signal strong; time to chart a longer arc.")
+
+        return {
+            "summary": " ".join(summary_parts),
+            "control_core": control_core,
+            "expansion_vector": expansion_vector,
+            "recommended_checkpoint": "lunar-gate" if expansion_vector == "trail" else "stone-circle",
+        }
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _bounded_float(value: Any, *, fallback: float) -> float:
+        numeric = IntrospectiveIntegrationTool._safe_float(value)
+        if numeric is None:
+            return fallback
+        return max(0.0, min(1.0, numeric))
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_number(value: Any) -> bool:
+        try:
+            float(value)
+            return True
+        except (TypeError, ValueError):
+            return False
+

--- a/synergyx/tools/registry.py
+++ b/synergyx/tools/registry.py
@@ -9,6 +9,8 @@ from .code_analysis import PythonASTAnalyzer, CodeLinterTool
 from .data_analysis import DataAnalyzerTool, DataExplainerTool, CSVUploaderTool
 from .web_fetcher import WebFetcherTool
 from .rag_tools import RAGSearchTool, RAGAnswerTool, RAGIndexTool
+from .field_observation import NocturnalFieldInsightTool
+from .introspective_integration import IntrospectiveIntegrationTool
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +41,12 @@ def register_all_tools() -> List[str]:
         RAGSearchTool(),
         RAGAnswerTool(),
         RAGIndexTool(),
+
+        # Field operations
+        NocturnalFieldInsightTool(),
+
+        # Introspective planning
+        IntrospectiveIntegrationTool(),
     ]
     
     registered_names = []


### PR DESCRIPTION
## Summary
- add an introspective integration tool that evaluates capabilities, readiness signals, and candidate expansions to surface deliberate growth paths
- extend the shared registry so the introspective integration planner is available alongside existing tools

## Testing
- `python -m compileall synergyx/tools/introspective_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4c2183468832db1e589c433690802